### PR TITLE
Correct all ReSpec warnings and fix a couple links

### DIFF
--- a/touchevents.html
+++ b/touchevents.html
@@ -35,7 +35,7 @@
           previousMaturity:  "REC",
 
           // if there a publicly available Editor's Draft, this is the link
-          edDraftURI:           "http://rawgit.com/w3c/touch-events/v1-errata/touchevents.html",
+          edDraftURI:           "http://w3c.github.io/touch-events/touchevents.html",
 
           // if this is a LCWD, uncomment and set the end of its review period
           // lcEnd: "2013-02-14",

--- a/touchevents.html
+++ b/touchevents.html
@@ -65,7 +65,7 @@
                 href: 'https://github.com/w3c/touch-events/issues'
             }, {
                 value: 'Commit history.',
-                href: 'https://github.com/w3c/touch-events/commits/v1-errata'
+                href: 'https://github.com/w3c/touch-events/commits/gh-pages'
             }, {
                 value: 'Mailing list.',
                 href: 'http://lists.w3.org/Archives/Public/public-touchevents/'

--- a/touchevents.html
+++ b/touchevents.html
@@ -41,10 +41,6 @@
           // lcEnd: "2013-02-14",
           // prEnd: "2013-06-06",
 
-          // if you want to have extra CSS, append them to this list
-          // it is recommended that the respec.css stylesheet be kept
-          extraCSS:             ["http://dev.w3.org/2009/dap/ReSpec.js/css/respec.css"],
-
           // editors, add as many as you like
           // only "name" is required
           editors:  [
@@ -636,9 +632,9 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         </p>
 
         <p>
-          The target of this event must be an <a><code>Element</code></a>. If the touch
+          The target of this event must be an <code>Element</code>. If the touch
           point is within a frame, the event should be dispatched to an element
-          in the <a>child browsing context</a> of that frame.
+          in the child browsing context of that frame.
         </p>
 
         <p>
@@ -659,7 +655,7 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         </p>
 
         <p>
-          The target of this event must be the same <a><code>Element</code></a> on
+          The target of this event must be the same <code>Element</code> on
           which the <a>touch point</a> started when it was first
           placed on the surface, even if the <a>touch point</a> has since moved
           outside the interactive area of the target element.
@@ -667,8 +663,10 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
 
         <p>
           The <a>touch point</a> or points that were removed must be included
-          in the <a><code>changedTouches</code></a> attribute of the <a><code>TouchEvent</code></a>, and
-          must not be included in the <a><code>touches</code></a> and <a><code>targetTouches</code></a>
+          in the <a href="#widl-TouchEvent-changedTouches"><code>changedTouches</code></a>
+          attribute of the <a><code>TouchEvent</code></a>, and must not be
+          included in the <a href="#widl-TouchEvent-touches"><code>touches</code></a>
+          and <a href="#widl-TouchEvent-targetTouches"><code>targetTouches</code></a>
           attributes.
         </p>
 
@@ -687,7 +685,7 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         </p>
 
         <p>
-          The target of this event must be the same <a><code>Element</code></a> on
+          The target of this event must be the same <code>Element</code> on
           which the <a>touch point</a> started when it was first
           placed on the surface, even if the <a>touch point</a> has since moved
           outside the interactive area of the target element.
@@ -726,7 +724,7 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         </p>
 
         <p>
-          The target of this event must be the same <a><code>Element</code></a> on
+          The target of this event must be the same <code>Element</code> on
           which the <a>touch point</a> started when it was first
           placed on the surface, even if the <a>touch point</a> has since moved
           outside the interactive area of the target element.
@@ -734,8 +732,8 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
 
         <p>
           The <a>touch point</a> or points that were removed must be included
-          in the <a><code>changedTouches</code></a> attribute of the <a><code>TouchEvent</code></a>, and
-          must not be included in the <a><code>touches</code></a> and <a><code>targetTouches</code></a>
+          in the <a href="#widl-TouchEvent-changedTouches"><code>changedTouches</code></a> attribute of the <a><code>TouchEvent</code></a>, and
+          must not be included in the <a href="#widl-TouchEvent-touches"><code>touches</code></a> and <a href="#widl-TouchEvent-targetTouches"><code>targetTouches</code></a>
           attributes.
         </p>
       </section>
@@ -780,8 +778,8 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         <a><code>TouchEvent</code></a> interface. When this method is available, scripts
         can use it to initialize the properties of a <a><code>TouchEvent</code></a> object,
         including its <a><code>TouchList</code></a> properties (which can be initialized
-        with values returned from <a><code>createTouchList</code></a>). The
-        <a><code>initTouchEvent</code></a> method is not yet standardized, but it may appear
+        with values returned from <a href="#widl-Document-createTouchList-TouchList-Touch-touches"><code>createTouchList</code></a>). The
+        <code>initTouchEvent</code> method is not yet standardized, but it may appear
         in some form in a future specification.
       </p>
     </section>
@@ -815,8 +813,8 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
 
       <p id="click-events">
         If the user agent interprets a sequence of touch events as a click,
-        then it should dispatch <a><code>mousemove</code></a>, <a><code>mousedown</code></a>,
-        <a><code>mouseup</code></a>, and <a><code>click</code></a> events (in that order) at the location
+        then it should dispatch <code>mousemove</code>, <code>mousedown</code>,
+        <code>mouseup</code>, and <code>click</code> events (in that order) at the location
         of the <a><code>touchend</code></a> event for the corresponding touch input. If the
         contents of the document have changed during processing of the touch
         events, then the user agent may dispatch the mouse events to a


### PR DESCRIPTION
Mostly this just corrects (or removes) links which ReSpec could not automatically find the target for.  ReSpec now runs without any warnings.

Also corrects a couple GitHub links for the current branch.
