### PR TITLE
Canceling a touchmove should not prevent dispatching of clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,7 +848,7 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
         user agent dispatches both touch events and mouse events in response to
         a single user action, then the <a><code>touchstart</code></a> event type must be
         dispatched before any mouse event types for that action.
-        If <a><code>touchstart</code></a>, <a><code>touchmove</code></a>, or <a><code>touchend</code></a>
+        If <a><code>touchstart</code></a> or <a><code>touchend</code></a>
         are <a href="#dfn-canceled-event">canceled</a>, the user agent should not dispatch any mouse
         event that would be a consequential result of the the prevented touch
         event.


### PR DESCRIPTION
Existing behaviour in Chrome for Android (and I believe Safari on iOS as well) is to dispatch a click if preventDefault is called on the first touchmove. The only default action that is prevented in this case is panning. Updating spec to match this behaviour. We are updating Firefox OS to match this behaviour as well in https://bugzilla.mozilla.org/show_bug.cgi?id=1174532 and its dependency. Firefox on Android will inherit this behaviour in the near future when it switches to using the same platform code that Firefox OS uses.
