### PR TITLE
Removed undefined link initTouchEvent

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,11 +946,11 @@ document.getElementById('touchable').addEventListener('touchend', function(ev) {
       </p>
 
       <section>
-        <h3>Initializers for interface TouchEvent</h3>
+        <h3>Initializers for interface <a><code>TouchEvent</code></a></h3>
         <p class="note">
           The argument list to this legacy TouchEvent initializer includes 6 unused arguments
           which have no defined semantics and are only for compatibility with existing implementations.
-          The <a><code>initTouchEvent</code></a> method is superseded by the <code>TouchEvent</code> constructor.
+          The <a><code>TouchEvent.initTouchEvent</code></a> method is superseded by the <a><code>TouchEvent</code></a> constructor.
         </p>
         <pre class='idl'>
           partial interface TouchEvent {


### PR DESCRIPTION
Fixing #50 by removing `<a>` around `initTouchEvent` since we actually don't have to link to anywhere

Preview it here: https://rawgit.com/choniong/touch-events/fix-initTouchEvent-warning/index.html#h-legacy-event-initializers

---

Actually change `initTouchEvent` to `TouchEvent.initTouchEvent` would be a better solution.
