### PR TITLE
Switch to the right profile of ReSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common.js' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove'>
       var respecConfig = {
           // specification status (e.g. WD, LC, NOTE, etc.). If in doubt use ED.
@@ -84,14 +84,8 @@
           //      company: "Your Company", companyURL: "http://example.com/" },
           //],
 
-          // name of the WG
-          wg:           "Touch Events Community Group",
-
-          // URI of the public WG page
-          wgURI:        "https://www.w3.org/community/touchevents/",
-
-          // name (with the @w3c.org) of the public mailing to which comments are due
-          wgPublicList: "public-touchevents",
+          // Name of the group
+          group: "touchevents",
 
           // URI of the patent status for this WG, for Rec-track documents
           // !!!! IMPORTANT !!!!
@@ -101,7 +95,7 @@
           // wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/45559/status",
         
           // Enables automatic linking
-          xref: "web-platform",
+          xref: ["html", "dom", "infra", "uievents"]
       };
     </script>
     <script id="fixuphook">


### PR DESCRIPTION
The spec referenced an outdated profile of ReSpec. Some editing features were not supported as a result.

Also see: https://github.com/w3c/webref/issues/560#issuecomment-1098302345