### PR TITLE
Change `may` to `should` for non-cancelable events

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@ document.body.dispatchEvent(touchEvent);
           <code>true</code>.
         </p> 
         <p>
-          In particular, a user agent may generate only uncancelable touch events when it
+          In particular, a user agent should generate only uncancelable touch events when it
           <a href="https://dom.spec.whatwg.org/#observing-event-listeners">observes that there
           are no non-passive listeners</a> for the event.
         </p>


### PR DESCRIPTION
Closes https://github.com/w3c/touch-events/issues/130


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/touch-events/pull/131.html" title="Last updated on Jun 29, 2022, 9:47 AM UTC (c69cff4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/touch-events/131/b655ac4...c69cff4.html" title="Last updated on Jun 29, 2022, 9:47 AM UTC (c69cff4)">Diff</a>