### PR TITLE
Remove outdated "Issues" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1138,16 +1138,6 @@ target.addEventListener('click', ...);
       </dl>
     </section>
 
-    <section id='issues' class='informative'>
-      <h2>Issues</h2>
-      <p>
-        The working group maintains <a
-         href='http://www.w3.org/2010/webevents/track/issues/open'
-        >a list of open issues in this specification</a>. These issues may be
-        addressed in future revisions of the specification.
-      </p>
-    </section>
-
     <section class='appendix informative'>
       <h2>Acknowledgements</h2>
       <p>


### PR DESCRIPTION
points to now defunct https://www.w3.org/2010/webevents/track/issues/open


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/touch-events/pull/132.html" title="Last updated on Jun 29, 2022, 9:50 AM UTC (dbbe82a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/touch-events/132/9a6a66c...dbbe82a.html" title="Last updated on Jun 29, 2022, 9:50 AM UTC (dbbe82a)">Diff</a>